### PR TITLE
fix Podfile

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,13 +3,13 @@ platform :ios, '9.0'
 # Uncomment this line if you're using Swift
 # use_frameworks!
 
-target 'shadowsocks' do
-    pod "libsodium"
-end
+#target 'shadowsocks' do
+#    pod "libsodium"
+#end
 
-target 'libshadowsocks' do
-    pod "libsodium"
-end
+#target 'libshadowsocks' do
+#    pod "libsodium"
+#end
 
 target 'ShadowsocksX' do
     platform :osx, '10.9'


### PR DESCRIPTION
fix pod install error（CocoaPods Version 1.0.1）
_[!] Unable to find a target named `libshadowsocks`, did find `ShadowsocksX` and `shadowsocks_sysconf`._
